### PR TITLE
Use correct sigclass

### DIFF
--- a/src/key_data.rs
+++ b/src/key_data.rs
@@ -29,7 +29,7 @@ impl KeyData {
             &self.keypair,
             data,
             self.fingerprint(),
-            pbp::SigType::GenericCertification,
+            pbp::SigType::BinaryDocument,
             timestamp as u32,
         ))
     }


### PR DESCRIPTION
Tested against gpg and this fixes #2

From looking at gpg source it seems like 0x10 (GenericCertification) as well as 0x11,12 and 13 are used to sign someone else's key saying you trust it, but not to sign code.

Thanks for the help on this :+1: 